### PR TITLE
Make the extension working again and update to manifest v3

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,9 +1,10 @@
 // this is the background code...
 
 // listen for our browerAction to be clicked
-chrome.browserAction.onClicked.addListener(function (tab) {
+chrome.action.onClicked.addListener(function (tab) {
 	// for the current tab, inject the "inject.js" file & execute it
-	chrome.tabs.executeScript(tab.ib, {
-		file: 'inject.js'
+	chrome.scripting.executeScript({
+	  target: {tabId: tab.id},
+	  files: ['inject.js']
 	});
 });

--- a/inject.js
+++ b/inject.js
@@ -1,19 +1,11 @@
 // this is the code which will be injected into a given page...
 
 (function() {
-
-document.querySelector('input[value="41"]').checked=true;
-document.querySelector('input[value="37"]').checked=true;
-document.querySelector('input[value="33"]').checked=true;
-document.querySelector('input[value="29"]').checked=true;
-document.querySelector('input[value="27"]').checked=true;
-document.querySelector('input[value="23"]').checked=true;
-document.querySelector('input[value="19"]').checked=true;
-document.querySelector('input[value="16"]').checked=true;
-document.querySelector('input[value="12"]').checked=true;
-document.querySelector('input[value="9"]').checked=true;
-document.querySelector('input[value="6"]').checked=true;
+for(let i=0; i<50; i++){
+	var buttons = document.getElementsByName(`right${i}`);
+	if(buttons[0]){
+		buttons[0].checked = true;	
+	}
+}
 document.querySelector('input[value="Submit"]').disabled = false;
-
-
 })();

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "Feedback Filler",
     "version": "1.0",
-    "manifest_version": 2,
+    "manifest_version": 3,
     "description": "Whose got the time to sit and click each of those option. Let this extension do it for ya..",
     "icons": {
         "16": "icons/checker_16x16.png",
@@ -10,18 +10,14 @@
         "128": "icons/checker_128x128.png"
       },
     "background": {
-      "scripts": [
-        "background.js"
-      ],
-      "persistent": true
+    	"service_worker": "background.js"
     },
-    "browser_action": {
+    "action": {
       "default_title": "Fill em Up!"
     },
     "permissions": [
-      "https://*/*",
-      "http://*/*",
       "tabs",
-      "activeTab"
+      "activeTab",
+      "scripting"
     ]
   }


### PR DESCRIPTION
Hey,
        As the semesters are going to end, this is again the season of faculty valuation feedbacks. So when I tried the extension, it was only selecting the first one or two radio buttons. So I've modified the code to make it work again. The new approach will select the radio buttons by their name (All feedback buttons are starting with the word `right`), and then make the first radio button (Excellent) checked.  Also, as manifest v2 is going to be deprecated in January 2023, I've updated the extension to manifest v3. Once again thank you for the beautiful extension :)